### PR TITLE
Add separate file for projects and organizations

### DIFF
--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -1,0 +1,12 @@
+# Projects and Organizations
+
+This file contains a list of projects and organizations that are friendly to
+contributions, along with quick links to relevant documents you should reference
+before contributing.
+
+- freeCodeCamp (org)
+    - [freeCodeCamp](https://github.com/FreeCodeCamp/FreeCodeCamp/) (project)
+        - [Contributing guide](https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/CONTRIBUTING.md
+        - Issue labels:
+            - [first-timers-only](https://github.com/FreeCodeCamp/FreeCodeCamp/issues?q=is%3Aopen+is%3Aissue+label%3Afirst-timers-only)
+            - [help wanted](https://github.com/freeCodeCamp/freeCodeCamp/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)


### PR DESCRIPTION
In order to keep the README.md file simple and not too cluttered, a separate file for projects and organizations friendly to contributions is created.

This file will set the structure for the projects and organizations so others can contribute to this file and start closing the issues we have on this repo :smile: 

I've formatted the file based on our discussions on #36. Let me know if we need to change this.

Related #36 