### PR TITLE
Adds the Pro Git Book in Using Version Control Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,4 @@ Search links that point directly to suitable issues to contribute to on GitHub
 - [freeCodeCamp's Wiki on Git Resources](http://forum.freecodecamp.com/t/wiki-git-resources/13136)
 - [GitHub Flow](https://www.youtube.com/watch?v=juLIxo42A_s) - GitHub talk on how to make a pull request
 - [GitHub Learning Resources](https://help.github.com/articles/git-and-github-learning-resources/) - Git and GitHub learning resources
+- [Pro Git](https://git-scm.com/book/en/v2) - The entire Pro Git book, written by Scott Chacon and Ben Straub and published by Apress.


### PR DESCRIPTION
Well, I've just seen that you put a link to the Pro Git Book in the CONTRIBUTING.md file, but I think it should also be in the README.md file because it's the first thing people read and in my opinion that is the most useful resource.