### PR TITLE
Added read the docs

### DIFF
--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -7,12 +7,13 @@ before contributing.
 - freeCodeCamp (org)
     - [freeCodeCamp](https://github.com/FreeCodeCamp/FreeCodeCamp/) (project)
         - [Contributing guide](https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/CONTRIBUTING.md)
+          - [Read the Docs](http://docs.readthedocs.io/en/latest/index.html)
         - Issue labels:
             - [first-timers-only](https://github.com/FreeCodeCamp/FreeCodeCamp/issues?q=is%3Aopen+is%3Aissue+label%3Afirst-timers-only)
             - [help wanted](https://github.com/freeCodeCamp/freeCodeCamp/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
+            - [Good First Bug](https://github.com/rtfd/readthedocs.org/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+First+Bug%22)
 - Servo (org)
     - [Servo](https://starters.servo.org/) (project)
         - [Contributing guide](https://github.com/servo/servo/blob/master/CONTRIBUTING.md)
         - Issue labels:
             - [Easy](https://github.com/servo/servo/issues?q=is%3Aissue+is%3Aopen+label%3AE-easy)
-            

--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -7,11 +7,13 @@ before contributing.
 - freeCodeCamp (org)
     - [freeCodeCamp](https://github.com/FreeCodeCamp/FreeCodeCamp/) (project)
         - [Contributing guide](https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/CONTRIBUTING.md)
-          - [Read the Docs](http://docs.readthedocs.io/en/latest/index.html)
         - Issue labels:
             - [first-timers-only](https://github.com/FreeCodeCamp/FreeCodeCamp/issues?q=is%3Aopen+is%3Aissue+label%3Afirst-timers-only)
             - [help wanted](https://github.com/freeCodeCamp/freeCodeCamp/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
-            - [Good First Bug](https://github.com/rtfd/readthedocs.org/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+First+Bug%22)
+- Read the docs (org)
+    - [Read the Docs](http://docs.readthedocs.io/en/latest/index.html) (site)
+      - Issue labels:
+        - [Good First Bug](https://github.com/rtfd/readthedocs.org/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+First+Bug%22)
 - Servo (org)
     - [Servo](https://starters.servo.org/) (project)
         - [Contributing guide](https://github.com/servo/servo/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
Issue:
https://github.com/freeCodeCamp/how-to-contribute-to-open-source/issues/
7

Added the link: _Read the docs_ (http://docs.readthedocs.io/en/latest/index.html) under the **Contributing Guide** point, also added _Good First Bug_, with its link under **Issue labels**

I am not sure if the structure of links is as expected and if it is not, then kindly let me know what is the expected structure of bullet points and I will update it.