### PR TITLE
Add link to contribute-to-open-source

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you have questions or comments, please create an issue.
 - [45 Github Issues Dos and Don’ts](https://hackernoon.com/45-github-issues-dos-and-donts-dfec9ab4b612)- Do's and Don'ts on GitHub.
 - [GitHub Guides](https://guides.github.com/) - basic guides on how to use GitHub effectively.
 - [First Contributions](https://roshanjossey.github.io/first-contributions) - Make your first open source contribution in 5 minutes. A tool and tutorial to help beginners get started with contributions.
-- [Contribute to Open Source](https://github.com/danthareja/contribute-to-open-source) - Learn the GitHub workflow by contributing code to a simulation project
+- [Contribute to Open Source](https://github.com/danthareja/contribute-to-open-source) - Learn the GitHub workflow by contributing code to a simulation project.
 
 ## Direct GitHub searches
 Search links that point directly to suitable issues to contribute to on GitHub.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ If you have questions or comments, please create an issue.
 - [45 Github Issues Dos and Don’ts](https://hackernoon.com/45-github-issues-dos-and-donts-dfec9ab4b612)- Do's and Don'ts on GitHub.
 - [GitHub Guides](https://guides.github.com/) - basic guides on how to use GitHub effectively.
 - [First Contributions](https://roshanjossey.github.io/first-contributions) - Make your first open source contribution in 5 minutes. A tool and tutorial to help beginners get started with contributions.
+- [Contribute to Open Source](https://github.com/danthareja/contribute-to-open-source) - Learn the GitHub workflow by contributing code to a simulation project
 
 ## Direct GitHub searches
 Search links that point directly to suitable issues to contribute to on GitHub.


### PR DESCRIPTION
Hey there!

I recently released a project that aims to empower new contributors by teaching them the mechanics of the GitHub pull request process in an interactive experience.

https://github.com/danthareja/contribute-to-open-source

In this project, users are given tests and tasked with writing code to DRY up an existing codebase. When they submit a PR, there's some fun back and forth with a bot that interprets their CI results and eventually merges their code.

I'd like to increase exposure to this project to as many new contributors as possible, and thought it would make a nice addition to this page.