### PR TITLE
fix: remove outdated link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ If you have questions or comments, please create an issue.
 - [Issuehub.io](http://issuehub.io/) - a tool for searching GitHub issues by label and language.
 - [Code Triage](https://www.codetriage.com/) - another, really nice, tool for finding popular repositories and issues filtered by language.
 - [First Timers Only](http://www.firsttimersonly.com/) - a list of bugs that are labelled "first-timers-only".
-- [YourFirstPR](https://twitter.com/yourfirstpr) - starter issues on GitHub that can be easily tackled by new contributors.
 - [Awesome-for-beginners](https://github.com/MunGell/awesome-for-beginners) - a GitHub repo that amasses projects with good bugs for new contributors, and applies labels to describe them.
 - [Open Source Guides](https://opensource.guide/) - Collection of resources for individuals, communities, and companies who want to learn how to run and contribute to an open source project.
 - [45 Github Issues Dos and Don’ts](https://hackernoon.com/45-github-issues-dos-and-donts-dfec9ab4b612)- Do's and Don'ts on GitHub.


### PR DESCRIPTION
The linked twitter account (https://twitter.com/yourfirstpr) had not made any tweets since April 15th, 2017, so the issues linked therein are most likely all closed by now.