### PR TITLE
Added reasoning for translation to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,8 @@ When adding your contribution to the list, please add your link to the most appr
 
 The main `README.md` file is written in English. That file will be the template for all the other languages.
 
+This repository is about contributing to open source and generally, translation is important to reaching diverse audiences. It is recommended that you provide language specific resources links instead of the Engligh resource links.
+
 The non-English README files are named `README-XX.md`, where `xx` is the
 [two letter language code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
 for the language.
@@ -138,8 +140,6 @@ You can contribute to the non-English README files by taking links that are in t
 If your language does not exist yet, feel free to start it yourself. If you decide to do this, please add more than just the title. If you do not have the time to create one, feel free to
 [create an issue](https://github.com/freeCodeCamp/how-to-contribute-to-open-source/issues/new/choose)
 to crowdsource help.
-
-This repository is about contributing to open source and generally, translation is important to reaching diverse audiences. It is recommended that you provide language specific resources links instead of the Engligh resource links.
 
 ### Adding to the Project File
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,8 @@ If your language does not exist yet, feel free to start it yourself. If you deci
 [create an issue](https://github.com/freeCodeCamp/how-to-contribute-to-open-source/issues/new/choose)
 to crowdsource help.
 
+This repository is about contributing to open source and generally, translation is important to reaching diverse audiences. It is recommended that you provide language specific resources links instead of the Engligh resource links.
+
 ### Adding to the Project File
 
 We have a


### PR DESCRIPTION
As discussed in #500, I have added reasoning for translation in the CONTRIBUTING.md file.
Objective is to encourage translation contributors to add more language resource links instead of simply linking to English resource links.