### PR TITLE
Add MDN Web Docs under Mozilla's contributor ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Search links that point directly to suitable issues to contribute to on GitHub.
 
 ## Mozilla's contributor ecosystem
 - [Good First Bugs](https://bugzil.la/sw:%22[good%20first%20bug]%22&limit=0) - bugs that developers have identified as a good introduction to the project.
+- [MDN Web Docs](https://developer.mozilla.org/en-US/docs/MDN/Contribute) - help the MDN Web Docs team in documenting the web platform by fixing content issues and platform bugs.
 - [Mentored Bugs](https://bugzilla.mozilla.org/buglist.cgi?quicksearch=mentor%3A%40) - bugs that have a mentor assigned who will be there on IRC to help you when you get stuck while working on a fix.
 - [Bugs Ahoy](https://www.joshmatthews.net/bugsahoy/) - a site dedicated to finding bugs on Bugzilla.
 - [Firefox DevTools](http://firefox-dev.tools/) - a site dedicated to bugs filed for the developer tools in the Firefox browser.


### PR DESCRIPTION
This PR adds [MDN Web Docs](https://developer.mozilla.org) under the Mozilla's contributor ecosystem. MDN Web Docs' content has been shifted to PR-based content reviewal. So we invite the GitHub open-sourcers help MDN document the web for everyone: https://developer.mozilla.org/en-US/docs/MDN/Contribute.

cc @erictleung.