### PR TITLE
fix a link in Direct GitHub searches Sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ If you have questions or comments, please create an issue.
 - [is:issue is:open label:starter](https://github.com/search?q=is%3Aissue+is%3Aopen+label%3Astarter&type=issues)
 - [is:issue is:open label:up-for-grabs](https://github.com/search?q=is%3Aissue+is%3Aopen+label%3Aup-for-grabs&type=issues)
 - [is:issue is:open label:easy-fix](https://github.com/search?q=is%3Aissue+is%3Aopen+label%3Aeasy-fix&type=issues)
-- [is:issue is:open label:"beginner friendly"](https://github.com/search?q=beginner+friendly&state=open&type=Issues)
+- [is:issue is:open label:"beginner friendly"](https://github.com/search?q=is%3Aissue+is%3Aopen+label%3A%22beginner+friendly%22&type=issues)
 
 ## Mozilla's contributor ecosystem
 

--- a/README.md
+++ b/README.md
@@ -45,16 +45,15 @@ If you have questions or comments, please create an issue.
 
 **Contents**
 
-- [Welcome Newbie Open Source Contributors!](#welcome-newbie-open-source-contributors)
-  - [Contributing to Open Source in general](#contributing-to-open-source-in-general)
-  - [Direct GitHub searches](#direct-github-searches)
-  - [Mozilla's contributor ecosystem](#mozillas-contributor-ecosystem)
-  - [Useful articles for new Open Source contributors](#useful-articles-for-new-open-source-contributors)
-  - [Using Version Control](#using-version-control)
-  - [Open Source books](#open-source-books)
-  - [Open Source contribution initiatives](#open-source-contribution-initiatives)
-  - [Open Source programs to participate in](#open-source-programs-to-participate-in)
-  - [License](#license)
+- [Contributing to Open Source in general](#contributing-to-open-source-in-general)
+- [Direct GitHub searches](#direct-github-searches)
+- [Mozilla's contributor ecosystem](#mozillas-contributor-ecosystem)
+- [Useful articles for new Open Source contributors](#useful-articles-for-new-open-source-contributors)
+- [Using Version Control](#using-version-control)
+- [Open Source books](#open-source-books)
+- [Open Source contribution initiatives](#open-source-contribution-initiatives)
+- [Open Source programs to participate in](#open-source-programs-to-participate-in)
+- [License](#license)
 
 ## Contributing to Open Source in general
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.

<!-- Feel free to add any additional description of changes below this line -->
The link of `is:issue is:open label:"beginner friendly"` does not meet the requirements and should be changed.
