### PR TITLE
fixes/Automate ISO 639 Suffix Check for README Files

### DIFF
--- a/.github/workflows/language-check.yml
+++ b/.github/workflows/language-check.yml
@@ -26,7 +26,8 @@ jobs:
       run: |
         # Scrape ISO 639 language codes from the Wiki page
         wget -qO- https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes | \
-        nokogiri - -e 'puts $_.css(".wikitable td:first-child").map(&:text)' > iso639.txt
+        nokogiri -e 'puts $_.css(".wikitable td:nth-child(2)").map(&:text)' | \
+        sed -nr '/^.{0,2}$/p' > iso639.txt  # Grab only two letter values
 
         # Get list of README file names
         readme_suffixes=$(ls README-* | sed 's/README-//g; s/.md//g')

--- a/.github/workflows/language-check.yml
+++ b/.github/workflows/language-check.yml
@@ -1,0 +1,44 @@
+name: Check README Suffixes
+
+on:
+  pull_request:
+    paths:
+      - 'README-*'
+
+jobs:
+  check-readme-suffixes:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.0
+
+    - name: Install dependencies
+      run: |
+        gem install nokogiri
+
+    - name: Check README suffixes
+      run: |
+        # Scrape ISO 639 language codes from the Wiki page
+        wget -qO- https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes | \
+        nokogiri - -e 'puts $_.css(".wikitable td:first-child").map(&:text)' > iso639.txt
+
+        # Get list of README file names
+        readme_suffixes=$(ls README-* | sed 's/README-//g; s/.md//g')
+
+        # Check if README suffixes are valid ISO 639 language codes
+        for suffix in $readme_suffixes; do
+          if ! grep -qw "$suffix" iso639.txt; then
+            echo "Error: Invalid README suffix found: $suffix"
+            exit 1
+          fi
+        done
+
+        echo "All README suffixes are valid ISO 639 language codes."
+
+  # Add more steps for your existing workflow, e.g., running tests or other checks


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #946 
This pull request addresses issue #946 by introducing a GitHub Action that automatically checks the suffix of the README files to ensure they adhere to the ISO 639 standard.
//changes->
Added a GitHub Action to automate the check for README file suffixes.
The action uses pseudo code to scrape and compare two-letter codes with the ISO 639 language codes list.
If a README file has a non-compliant suffix, an error message is displayed; otherwise, the action passes.


<!-- Feel free to add any additional description of changes below this line -->
