### PR TITLE
Removed domain links that no longer worked on README.ES.

### DIFF
--- a/README-ES.md
+++ b/README-ES.md
@@ -47,7 +47,6 @@ Si tienes alguna pregunta o comentario, por favor crea un `issue` en este reposi
 
 - [Guía definitiva para contribuir al código abierto](https://medium.freecodecamp.org/the-definitive-guide-to-contributing-to-open-source-900d5f9f2282) por [@DoomHammerNG](https://twitter.com/DoomHammerNG)
 - [Una introducción al código abierto](https://www.digitalocean.com/community/tutorial_series/an-introduction-to-open-source) - Tutoriales hechos por DigitalOcean para guiarte de manera exitosa en tu camino cómo colaborador en GitHub.
-- [Issuehub.io](http://issuehub.pro/) - Buscador de `issues` en GitHub las cuáles puedes filtrar por tipo y lenguaje.
 - [Code Triage](https://www.codetriage.com/) - Otro muy buen buscador de repositorios e `issues` filtrados por lenguaje de programación.
 - [Awesome-for-beginners](https://github.com/MunGell/awesome-for-beginners) - Repositorio de GitHub que acumula proyectos con issues fáciles y etiquetados para colaboradores recien iniciados.
 - [Guías de código abierto](https://opensource.guide/) - Colección de recursos para particulares, comunidades y empresas que quieren aprender cómo iniciar y contribuir en proyectos de código abierto.
@@ -58,7 +57,6 @@ Si tienes alguna pregunta o comentario, por favor crea un `issue` en este reposi
 - [Trucos CSS, Guía de etiquetas de código abierto](https://css-tricks.com/open-source-etiquette-guidebook/) - Una guía de etiquetas de código abierto escrita por [Kent C. Dodds](https://github.com/kentcdodds) y [Sarah Drasner](https://github.com/sdras).
 - [Recursos de la A a la Z para estudiantes](https://github.com/dipakkr/A-to-Z-Resources-for-Students) - Lista precisa de recursos y oportunidades para estudiantes que quieran aprender un nuevo lenguaje de programación.
 - [Contribuyendo en tu primer proyecto de código abierto: Un acercamiento práctico.](https://blog.devcenter.co/contributing-to-your-first-open-source-project-a-practical-approach-1928c4cbdae) - Un acercamiento paso a paso para contribuir en tu primer proyecto de código abierto por [Abati Adewale](https://www.acekyd.com).
-- [Ruleta Pull Request](http://www.pullrequestroulette.com/) - Este sitio tiene una lista de `pull requests` enviadas para ser revisadas y que pertenecen a proyectos alojados en GitHub.
 - ["Cómo contribuir a un proyecto de código abierto en GitHub" por Egghead.io](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github) - Una videoguía paso a paso de cómo empezar a contribuir en un proyecto de código abierto en GitHub.
 
 ## Búsquedas directas en GitHub


### PR DESCRIPTION
Removed domain links that no longer worked.

I have removed some links to reference pages that were no longer in operation, these were: 
1-) http://issuehub.pro/
2-) http://www.pullrequestroulette.com/

![Dominio_no_sirve_issuehub pro](https://github.com/user-attachments/assets/14064041-a3ec-4f9e-9ca0-ab81e585f015)


![Dominio_no_sirve_heruko-app](https://github.com/user-attachments/assets/86c1ef52-3613-463b-9232-e57855c77f8a)




Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
